### PR TITLE
feat(types): export the `ClassValue` type

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -8,6 +8,11 @@ import type {
 } from "./_internal.ts";
 
 /**
+ * Type for arguments to the `clsx` function.
+ */
+export type { ClassValue } from "./_internal.ts";
+
+/**
  * @module clsx
  *
  * This module provides a type-safe utility for conditionally constructing


### PR DESCRIPTION
I'm keen to use this package, but I use a function that wraps a call to `clsx()`, accepting the same argument types. It would be helpful to have the `ClassValue` type exported.

I think this may be a reasonably common use case - I got the function from Shadcn UI:

https://ui.shadcn.com/docs/installation/manual#add-a-cn-helper